### PR TITLE
use an alternative way to "overwrite" the pipeworks tube-recipes

### DIFF
--- a/technic/crafts.lua
+++ b/technic/crafts.lua
@@ -159,30 +159,16 @@ minetest.register_craft({
 })
 
 -- Remove some recipes
-minetest.register_craftitem("technic:nothing", {
-	description = "",
-	inventory_image = "blank.png",
-	groups = { not_in_creative_inventory = 1 },
-})
-
-if minetest.register_craft_predict then
-	minetest.register_craft_predict(function(itemstack, player, old_craft_grid, craft_inv)
-		if itemstack:get_name() == "technic:nothing" then
-			return ItemStack("")
-		end
-	end)
-end
-
 -- Bronze
 minetest.register_craft({
 	type = "shapeless",
-	output = "technic:nothing",
+	output = "default:bronze_ingot 0",
 	recipe = {"default:copper_ingot", "default:steel_ingot"}
 })
 
 -- Accelerator tube
 minetest.register_craft({
-	output = "technic:nothing",
+	output = "pipeworks:accelerator_tube_1 0",
 	recipe = {
 	        { "homedecor:plastic_sheeting", "homedecor:plastic_sheeting", "homedecor:plastic_sheeting" },
 	        { "default:mese_crystal_fragment", "default:steel_ingot", "default:mese_crystal_fragment" },
@@ -192,7 +178,7 @@ minetest.register_craft({
 
 -- Teleport tube
 minetest.register_craft({
-	output = "technic:nothing",
+	output = "pipeworks:teleport_tube_1 0",
 	recipe = {
 	        { "homedecor:plastic_sheeting", "homedecor:plastic_sheeting", "homedecor:plastic_sheeting" },
 	        { "default:desert_stone", "default:mese_block", "default:desert_stone" },


### PR DESCRIPTION
This is an attempt of a different form of overwriting the recipes of pipeworks.
The former way was -- although inactive -- listed still in the crafting menu, leading people to try to craft these via autocrafters. Autocrafters do correctly craft these technic:nothing nodes, which are effective inventory-DoS items, as they cannot be differentiated from empty slots (unless stacked).

This is an alternative approach, that allows people to craft via these recipes but only returns the material as used back to them in both inventory as well as autocrafter.

I tried to get an opinion on this in irc but couldn't get any; thus this proactive question of this solution in form of a pullrequest.