### PR TITLE
Quarry optimisations/improvements

### DIFF
--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -36,3 +36,11 @@ function technic.function_exists(function_name)
 	return type(resolve_name(function_name)) == 'function'
 end
 
+-- if the node is loaded, returns it. If it isn't loaded, load it and return nil.
+function technic.get_or_load_node(pos)
+	local node_or_nil = minetest.get_node_or_nil(pos)
+	if node_or_nil then return node_or_nil end
+	local vm = VoxelManip()
+	local MinEdge, MaxEdge = vm:read_from_map(pos, pos)
+	return nil
+end

--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -108,21 +108,26 @@ local function quarry_run(pos, node)
 				vector.multiply(pdir, rp)),
 				vector.multiply(qdir, rq))
 			local can_dig = true
-			for ay = startpos.y, digpos.y+1, -1 do
-				if data[area:index(digpos.x, ay, digpos.z)] ~= c_air then
-					can_dig = false
-					break
-				end
-			end
 			if can_dig and minetest.is_protected and minetest.is_protected(digpos, owner) then
 				can_dig = false
 			end
 			local dignode
 			if can_dig then
-				dignode = minetest.get_node(digpos)
+				dignode = technic.get_or_load_node(digpos) or minetest.get_node(digpos)
 				local dignodedef = minetest.registered_nodes[dignode.name] or {diggable=false}
 				if not dignodedef.diggable or (dignodedef.can_dig and not dignodedef.can_dig(digpos, nil)) then
 					can_dig = false
+				end
+			end
+
+			if can_dig then
+				for ay = startpos.y, digpos.y+1, -1 do
+					local checkpos = {x=digpos.x, y=ay, z=digpos.z}
+					local checknode = technic.get_or_load_node(checkpos) or minetest.get_node(checkpos)
+					if checknode.name ~= "air" then
+						can_dig = false
+						break
+					end
 				end
 			end
 			nd = nd + 1

--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -209,6 +209,9 @@ minetest.register_node("technic:quarry", {
 	tiles = {"technic_carbon_steel_block.png", "technic_carbon_steel_block.png",
 	         "technic_carbon_steel_block.png", "technic_carbon_steel_block.png",
 	         "technic_carbon_steel_block.png^default_tool_mesepick.png", "technic_carbon_steel_block.png"},
+	inventory_image = minetest.inventorycube("technic_carbon_steel_block.png",
+	         "technic_carbon_steel_block.png^default_tool_mesepick.png",
+	         "technic_carbon_steel_block.png"),
 	paramtype2 = "facedir",
 	groups = {cracky=2, tubedevice=1, technic_machine = 1},
 	tube = {

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -82,15 +82,9 @@ local add_new_cable_node = function(nodes, pos)
 	return true
 end
 
-local load_position = function(pos)
-	if minetest.get_node_or_nil(pos) then return end
-	local vm = VoxelManip()
-	local MinEdge, MaxEdge = vm:read_from_map(pos, pos)
-end
-
 -- Generic function to add found connected nodes to the right classification array
 local check_node_subp = function(PR_nodes, RE_nodes, BA_nodes, SP_nodes, all_nodes, pos, machines, tier, sw_pos)
-	load_position(pos)
+	technic.get_or_load_node(pos)
 	local meta = minetest.get_meta(pos)
 	local name = minetest.get_node(pos).name
 
@@ -219,7 +213,7 @@ minetest.register_abm({
 		-- Run all the nodes
 		local function run_nodes(list)
 			for _, pos2 in ipairs(list) do
-				load_position(pos2)
+				technic.get_or_load_node(pos2)
 				local node2 = minetest.get_node(pos2)
 				local nodedef
 				if node2 and node2.name then


### PR DESCRIPTION
Makes quarries less resource-intensive. Don't forceload the whole digging range every time, also add a quarry cache that collects items and outputs them in stacks instead of single items.