### PR TITLE
machine upgrades and chainsaw fixes

### DIFF
--- a/technic/machines/register/common.lua
+++ b/technic/machines/register/common.lua
@@ -138,18 +138,22 @@ function technic.handle_machine_pipeworks(pos, tube_upgrade, send_function)
 	meta:set_int("tube_time", tube_time)
 end
 
-
 function technic.machine_can_dig(pos, player)
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
-	if not inv:is_empty("src") or not inv:is_empty("dst") or
-	   not inv:is_empty("upgrade1") or not inv:is_empty("upgrade2") then
+	if not inv:is_empty("src") or not inv:is_empty("dst") then
 		if player then
 			minetest.chat_send_player(player:get_player_name(),
 				S("Machine cannot be removed because it is not empty"))
 		end
 		return false
 	else
+		if not inv:is_empty("upgrade1") then
+			minetest.item_drop(inv:get_stack("upgrade1", 1), "", pos)
+		end
+		if not inv:is_empty("upgrade2") then
+			minetest.item_drop(inv:get_stack("upgrade2", 1), "", pos)
+		end
 		return true
 	end
 end

--- a/technic/machines/register/common.lua
+++ b/technic/machines/register/common.lua
@@ -131,25 +131,30 @@ function technic.machine_can_dig(pos, player)
 	end
 end
 
-local function inv_change(pos, player, count)
+local function inv_change(pos, player, count, from_list, to_list)
 	if minetest.is_protected(pos, player:get_player_name()) then
 		minetest.chat_send_player(player:get_player_name(),
 			S("Inventory move disallowed due to protection"))
 		return 0
 	end
+	if to_list == "upgrade1" or to_list == "upgrade2" then
+		-- only place a single item into it, if it's empty
+		local empty = minetest.get_meta(pos):get_inventory():is_empty(to_list)
+		return empty and 1 or 0
+	end
 	return count
 end
 
 function technic.machine_inventory_put(pos, listname, index, stack, player)
-	return inv_change(pos, player, stack:get_count())
+	return inv_change(pos, player, stack:get_count(), nil, listname)
 end
 
 function technic.machine_inventory_take(pos, listname, index, stack, player)
-	return inv_change(pos, player, stack:get_count())
+	return inv_change(pos, player, stack:get_count(), listname, nil)
 end
 
 function technic.machine_inventory_move(pos, from_list, from_index,
 		to_list, to_index, count, player)
-	return inv_change(pos, player, count)
+	return inv_change(pos, player, count, from_list, to_list)
 end
 

--- a/technic/tools/chainsaw.lua
+++ b/technic/tools/chainsaw.lua
@@ -14,7 +14,7 @@ local timber_nodenames = {
 	["default:cactus"]     = true,
 	["default:tree"]       = true,
 	["default:apple"]      = true,
-	["default:pine"]       = true,
+	["default:pinetree"]   = true,
 }
 
 if chainsaw_leaves then

--- a/technic/tools/chainsaw.lua
+++ b/technic/tools/chainsaw.lua
@@ -148,6 +148,14 @@ if minetest.get_modpath("vines") then
 	end
 end
 
+if minetest.get_modpath("trunks") then
+	if chainsaw_leaves then
+		timber_nodenames["trunks:moss"] = true
+		timber_nodenames["trunks:moss_fungus"] = true
+		timber_nodenames["trunks:treeroot"] = true
+	end
+end
+
 local S = technic.getter
 
 technic.register_power_tool("technic:chainsaw", chainsaw_max_charge)


### PR DESCRIPTION
* adds an upgrade item to make a machine public (unlocked chest)
* drop upgrade items if dug
* prevent setting unknown upgrades or more than one item into the uprade slots