### PR TITLE
Get rid of technic.format

### DIFF
--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -1,5 +1,5 @@
 --load config
-local sepchar, baresepchar = nil, nil
+local sepchar = nil
 do
 	local sepcode = technic.config:get("thousand_separator")
 	--default is SI style
@@ -58,38 +58,10 @@ function technic.get_or_load_node(pos)
 	return nil
 end
 
-function technic.format(str, ...)
-	local arg={...}
-	local param = nil
-	local percent = false
-	local res = ""
-	local i = 1
-	for c in str:gmatch"." do
-		if percent then
-			assert(c ~= "%") --syntax error
-			if c == "e" then
-				-- use enhanced number formatting
-				-- only works for unsigned numbers
-				local numstr = tostring(math.abs(arg[i]))
-				local a, b, body, frac = numstr:find("^(%d+)([.]?.-)$")
-				a = 1
-				body = body..baresepchar
-				while a ~= 0 do
-					body, a = body:gsub("(%d)(%d%d%d)"..sepchar, "%1"..sepchar.."%2"..sepchar, 1)
-				end
-				body = body:gsub(sepchar.."$", "")
-				res = res .. body .. frac
-			else
-				--use traditional string:format
-				res = res .. (string.format(("%"..c), arg[i]))
-			end
-			i = i + 1
-			percent = false
-		elseif c == "%" then
-			percent = true
-		else
-			res = res .. c
-		end
-	end
-	return res
+function technic.prettynum(num)
+	local str, k = tostring(num), nil
+	repeat
+		str, k = str:gsub("^(-?%d+)(%d%d%d)", "%1"..sepchar.."%2")
+	until k == 0
+	return str
 end

--- a/technic/init.lua
+++ b/technic/init.lua
@@ -16,8 +16,12 @@ local modpath = minetest.get_modpath("technic")
 technic.modpath = modpath
 
 -- Boilerplate to support intllib
-local S = rawget(_G, "intllib") and intllib.Getter() or function(s) return s end
-technic.getter = S
+if minetest.get_modpath("intllib") then
+	technic.getter = intllib.Getter()
+else
+	technic.getter = function(s,a,...)if a==nil then return s end a={a,...}return s:gsub("(@?)@(%(?)(%d+)(%)?)",function(e,o,n,c)if e==""then return a[tonumber(n)]..(o==""and c or"")else return"@"..o..n..c end end) end
+end
+local S = technic.getter
 
 -- Read configuration file
 dofile(modpath.."/config.lua")

--- a/technic/locale/de.txt
+++ b/technic/locale/de.txt
@@ -36,6 +36,7 @@ Rubber Fiber = Gummifaser
 Machine cannot be removed because it is not empty = Die Maschine kann nicht entfernt werden, weil sie noch nicht leer ist.
 Inventory move disallowed due to protection = Das Inventar ist geschuetzt, Zugriff verweigert.
 # $1: Machine name (Includes tier)
+@1 Active (@2 EU) = @1 ist eingeschaltet (@2 EU)
 %s Active = %s ist eingeschaltet
 %s Disabled = %s ist ausgeschaltet
 %s Enabled =
@@ -106,9 +107,9 @@ Charge = Aufladen
 Discharge = Entladen
 Power level = Energiestufe
 # $1: Tier $2: current_charge $3: max_charge 
-%s Battery Box: %d/%d = %s Batteriebox: %d/%d
+@1 Battery Box: @2/@3 = @1 Batteriebox: @2/@3
 # $1: Machine name $2: Supply $3: Demand
-%s. Supply: %d Demand: %d = %s. Versorgung: %d Bedarf: %d
+@1. Supply: @2 Demand: @3 = @1. Versorgung: @2 Bedarf: @3
 Production at %d%% = Produktion bei %d%%
 Choose Milling Program: = Waehle ein Fraesprogramm:
 Slim Elements half / normal height: = Schmale Elemente von halber / normaler Hoehe:

--- a/technic/locale/es.txt
+++ b/technic/locale/es.txt
@@ -36,6 +36,7 @@ Rubber Fiber = Fibra de Hule
 Machine cannot be removed because it is not empty = La maquina no puede removerse porque no esta vacia
 Inventory move disallowed due to protection =
 # $1: Machine name (Includes tier)
+@1 Active (@2 EU) = @1 Activo (@2 EU)
 %s Active = %s Activo
 %s Enabled =
 %s Idle = %s Quieto
@@ -102,9 +103,9 @@ Charge = Cargar
 Discharge = Descargar
 Power level = Nivel de Poder
 # $1: Tier $2: current_charge $3: max_charge 
-%s Battery Box: %d/%d = Caja de Bateria %s: %d/%d
+@1 Battery Box: @2/@3 = Caja de Bateria @1: @2/@3
 # $1: Machine name $2: Supply $3: Demand
-%s. Supply: %d Demand: %d = %s. Alimentacion: %d Demanda: %d
+@1. Supply: @2 Demand: @3 = @1. Alimentacion: @2 Demanda: @3
 # $1: Production percent
 Production at %d%% = Produccion en %d%%
 Stopped =

--- a/technic/locale/it.txt
+++ b/technic/locale/it.txt
@@ -33,6 +33,7 @@ Rubber Fiber = Fibra di gomma
 Machine cannot be removed because it is not empty = La macchina non può essere rimossa perchè non è vuota
 Inventory move disallowed due to protection = Impossibile muovere l'inventario a causa della protezione
 # $1: Machine name (Includes tier)
+@1 Active (@2 EU) = @1 Attivo (@2 EU)
 %s Active = %s Attivo
 %s Disabled = %s Disabilitato
 %s Enabled =
@@ -103,9 +104,9 @@ Charge = Carica
 Discharge = Scarica
 Power level = Livello di potenza
 # $1: Tier $2: current_charge $3: max_charge
-%s Battery Box: %d/%d = %s Box Batterie: %d/%d
+@1 Battery Box: @2/@3 = @1 Box Batterie: @2/@3
 # $1: Machine name $2: Supply $3: Demand
-%s. Supply: %d Demand: %d = %s. Prodotto: %d Consumato: %d
+@1. Supply: @2 Demand: @3 = @1. Prodotto: @2 Consumato: @3
 Production at %d%% = Produzione a %d%%
 Choose Milling Program: = Scegliere un programma di Fresatura
 Slim Elements half / normal height: = Metà elementi sottili / altezza normale:

--- a/technic/locale/template.txt
+++ b/technic/locale/template.txt
@@ -36,6 +36,7 @@ Rubber Fiber =
 Machine cannot be removed because it is not empty =
 Inventory move disallowed due to protection =
 # $1: Machine name (Includes tier)
+@1 Active (@2 EU) =
 %s Active =
 %s Disabled =
 %s Enabled =
@@ -68,7 +69,7 @@ Disabled =
 ## Machine names
 # $1: Tier
 %s Alloy Furnace =
-%s Battery Box = 
+%s Battery Box =
 %s Cable =
 %s CNC Machine =
 %s Centrifuge =
@@ -111,9 +112,9 @@ Charge =
 Discharge =
 Power level =
 # $1: Tier $2: current_charge $3: max_charge 
-%s Battery Box: %d/%d =
+@1 Battery Box: @2/@3 =
 # $1: Machine name $2: Supply $3: Demand
-%s. Supply: %d Demand: %d =
+@1. Supply: @2 Demand: @3 =
 Production at %d%% =
 Choose Milling Program: =
 Slim Elements half / normal height: =
@@ -124,6 +125,7 @@ Digging not started =
 Digging finished =
 Digging %d m above machine =
 Digging %d m below machine =
+@1 (@2 @3 -> @4 @5) =
 
 ## CNC
 Cylinder =

--- a/technic/machines/LV/solar_panel.lua
+++ b/technic/machines/LV/solar_panel.lua
@@ -24,7 +24,7 @@ local run = function(pos, node)
 		local charge_to_give = math.floor((light + pos1.y) * 3)
 		charge_to_give = math.max(charge_to_give, 0)
 		charge_to_give = math.min(charge_to_give, 200)
-		meta:set_string("infotext", technic.format(S("%s Active (%e EU)"), machine_name, charge_to_give))
+		meta:set_string("infotext", S("@1 Active (@2 EU)", machine_name, technic.prettynum(charge_to_give)))
 		meta:set_int("LV_EU_supply", charge_to_give)
 	else
 		meta:set_string("infotext", S("%s Idle"):format(machine_name))

--- a/technic/machines/MV/wind_mill.lua
+++ b/technic/machines/MV/wind_mill.lua
@@ -55,7 +55,7 @@ local run = function(pos, node)
 		meta:set_int("MV_EU_supply", power)
 	end
 
-	meta:set_string("infotext", technic.format("%s (%eEU)", machine_name, power))
+	meta:set_string("infotext", S("@1 (@2 EU)", machine_name, technic.prettynum(power)))
 end
 
 minetest.register_node("technic:wind_mill", {

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -142,8 +142,8 @@ function technic.register_battery_box(data)
 			.."^[lowpart:"..charge_percent
 			..":technic_power_meter_fg.png]")
 
-		local infotext = technic.format(S("%s Battery Box: %e/%e"), tier,
-				current_charge, max_charge)
+		local infotext = S("@1 Battery Box: @2/@3", tier,
+				technic.prettynum(current_charge), technic.prettynum(max_charge))
 		if eu_input == 0 then
 			infotext = S("%s Idle"):format(infotext)
 		end

--- a/technic/machines/register/solar_array.lua
+++ b/technic/machines/register/solar_array.lua
@@ -28,7 +28,7 @@ function technic.register_solar_array(data)
 			local charge_to_give = math.floor((light + pos.y) * data.power)
 			charge_to_give = math.max(charge_to_give, 0)
 			charge_to_give = math.min(charge_to_give, data.power * 50)
-			meta:set_string("infotext", technic.format(S("%s Active (%e EU)"), machine_name, charge_to_give))
+			meta:set_string("infotext", S("@1 Active (@2 EU)", machine_name, technic.prettynum(charge_to_give)))
 			meta:set_int(tier.."_EU_supply", charge_to_give)
 		else
 			meta:set_string("infotext", S("%s Idle"):format(machine_name))

--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -30,8 +30,7 @@ local run = function(pos, node)
 		meta:set_int(from.."_EU_supply", 0)
 		meta:set_int(to.."_EU_demand", 0)
 		meta:set_int(to.."_EU_supply", input * remain)
-		meta:set_string("infotext", machine_name
-			..technic.format(" (%e %s -> %e %s)", input, from, input * remain, to))
+		meta:set_string("infotext", S("@1 (@2 @3 -> @4 @5)", machine_name, technic.prettynum(input), from, technic.prettynum(input * remain), to))
 	else
 		meta:set_string("infotext", S("%s Has Bad Cabling"):format(machine_name))
 		if to then

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -292,8 +292,8 @@ minetest.register_abm({
 		--dprint("Total BA demand:"..BA_eu_demand)
 
 		meta:set_string("infotext",
-				technic.format(S("%s. Supply: %e Demand: %e"),
-				machine_name, PR_eu_supply, RE_eu_demand))
+				S("@1. Supply: @2 Demand: @3",
+				machine_name, technic.prettynum(PR_eu_supply), technic.prettynum(RE_eu_demand)))
 
 		-- If the PR supply is enough for the RE demand supply them all
 		if PR_eu_supply >= RE_eu_demand then


### PR DESCRIPTION
SN didnt like it, and it wasn't beautiful (and performant) either. Replaces technic.format, and uses the newest initlib features. Translations can update.