### PR TITLE
label the switching station abm for profiling purposes

### DIFF
--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -171,6 +171,7 @@ end
 -----------------------------------------------
 minetest.register_abm({
 	nodenames = {"technic:switching_station"},
+	label = "Switching Station", -- allows the mtt profiler to profile this abm individually
 	interval   = 1,
 	chance     = 1,
 	action = function(pos, node, active_object_count, active_object_count_wider)


### PR DESCRIPTION
this allows the mtt profiler to profile this abm individually from other abms since t4im/mtt@48eff13