### PR TITLE
Tools don't wear in creative mode v2

### DIFF
--- a/technic/init.lua
+++ b/technic/init.lua
@@ -3,6 +3,7 @@
 -- (c) 2012-2013 by RealBadAngel <mk@realbadangel.pl>
 
 technic = rawget(_G, "technic") or {}
+technic.creative_mode = minetest.setting_getbool("creative_mode")
 
 technic.tube_inject_item = pipeworks.tube_inject_item or function (pos, start_pos, velocity, item)
 	local tubed = pipeworks.tube_item(vector.new(pos), item)

--- a/technic/tools/chainsaw.lua
+++ b/technic/tools/chainsaw.lua
@@ -344,9 +344,10 @@ minetest.register_tool("technic:chainsaw", {
 		-- Send current charge to digging function so that the
 		-- chainsaw will stop after digging a number of nodes
 		meta.charge = chainsaw_dig(pointed_thing.under, meta.charge)
-
-		technic.set_RE_wear(itemstack, meta.charge, chainsaw_max_charge)
-		itemstack:set_metadata(minetest.serialize(meta))
+		if not technic.creative_mode then
+			technic.set_RE_wear(itemstack, meta.charge, chainsaw_max_charge)
+			itemstack:set_metadata(minetest.serialize(meta))
+		end
 		return itemstack
 	end,
 })

--- a/technic/tools/flashlight.lua
+++ b/technic/tools/flashlight.lua
@@ -40,10 +40,12 @@ local function check_for_flashlight(player)
 		if hotbar[i]:get_name() == "technic:flashlight" then
 			local meta = minetest.deserialize(hotbar[i]:get_metadata())
 			if meta and meta.charge and meta.charge >= 2 then
-				meta.charge = meta.charge - 2;
-				technic.set_RE_wear(hotbar[i], meta.charge, flashlight_max_charge)
-				hotbar[i]:set_metadata(minetest.serialize(meta))
-				inv:set_stack("main", i, hotbar[i])
+				if not technic.creative_mode then
+					meta.charge = meta.charge - 2;
+					technic.set_RE_wear(hotbar[i], meta.charge, flashlight_max_charge)
+					hotbar[i]:set_metadata(minetest.serialize(meta))
+					inv:set_stack("main", i, hotbar[i])
+				end
 				return true
 			end
 		end

--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -298,9 +298,11 @@ local function mining_drill_mk2_handler(itemstack, user, pointed_thing)
 	if meta.charge >= charge_to_take then
 		local pos = minetest.get_pointed_thing_position(pointed_thing, above)
 		drill_dig_it(pos, user, meta.mode)
-		meta.charge = meta.charge - charge_to_take
-		itemstack:set_metadata(minetest.serialize(meta))
-		technic.set_RE_wear(itemstack, meta.charge, max_charge[2])
+		if not technic.creative_mode then
+			meta.charge = meta.charge - charge_to_take
+			itemstack:set_metadata(minetest.serialize(meta))
+			technic.set_RE_wear(itemstack, meta.charge, max_charge[2])
+		end
 	end
 	return itemstack
 end
@@ -319,9 +321,11 @@ local function mining_drill_mk3_handler(itemstack, user, pointed_thing)
 	if meta.charge >= charge_to_take then
 		local pos = minetest.get_pointed_thing_position(pointed_thing, above)
 		drill_dig_it(pos, user, meta.mode)
-		meta.charge = meta.charge - charge_to_take
-		itemstack:set_metadata(minetest.serialize(meta))
-		technic.set_RE_wear(itemstack, meta.charge, max_charge[3])
+		if not technic.creative_mode then
+			meta.charge = meta.charge - charge_to_take
+			itemstack:set_metadata(minetest.serialize(meta))
+			technic.set_RE_wear(itemstack, meta.charge, max_charge[3])
+		end
 	end
 	return itemstack
 end
@@ -346,9 +350,11 @@ minetest.register_tool("technic:mining_drill", {
 		if meta.charge >= charge_to_take then
 			local pos = minetest.get_pointed_thing_position(pointed_thing, above)
 			drill_dig_it(pos, user, 1)
-			meta.charge = meta.charge - charge_to_take
-			itemstack:set_metadata(minetest.serialize(meta))
-			technic.set_RE_wear(itemstack, meta.charge, max_charge[1])
+			if not technic.creative_mode then
+				meta.charge = meta.charge - charge_to_take
+				itemstack:set_metadata(minetest.serialize(meta))
+				technic.set_RE_wear(itemstack, meta.charge, max_charge[1])
+			end
 		end
 		return itemstack
 	end,

--- a/technic/tools/mining_lasers.lua
+++ b/technic/tools/mining_lasers.lua
@@ -164,10 +164,12 @@ for _, m in pairs(mining_lasers_list) do
 
 			-- If there's enough charge left, fire the laser
 			if meta.charge >= m[4] then
-				meta.charge = meta.charge - m[4]
 				laser_shoot(user, m[2], "technic_laser_beam_mk"..m[1]..".png", "technic_laser_mk"..m[1])
-				technic.set_RE_wear(itemstack, meta.charge, m[3])
-				itemstack:set_metadata(minetest.serialize(meta))
+				if not technic.creative_mode then
+					meta.charge = meta.charge - m[4]
+					technic.set_RE_wear(itemstack, meta.charge, m[3])
+					itemstack:set_metadata(minetest.serialize(meta))
+				end
 			end
 			return itemstack
 		end,

--- a/technic/tools/prospector.lua
+++ b/technic/tools/prospector.lua
@@ -28,9 +28,11 @@ minetest.register_tool("technic:prospector", {
 			minetest.chat_send_player(user:get_player_name(), "Right-click to set target block type")
 			return
 		end
-		toolmeta.charge = toolmeta.charge - charge_to_take
-		toolstack:set_metadata(minetest.serialize(toolmeta))
-		technic.set_RE_wear(toolstack, toolmeta.charge, technic.power_tools[toolstack:get_name()])
+		if not technic.creative_mode then
+			toolmeta.charge = toolmeta.charge - charge_to_take
+			toolstack:set_metadata(minetest.serialize(toolmeta))
+			technic.set_RE_wear(toolstack, toolmeta.charge, technic.power_tools[toolstack:get_name()])
+		end
 		local start_pos = pointed_thing.under
 		local forward = minetest.facedir_to_dir(minetest.dir_to_facedir(user:get_look_dir(), true))
 		local right = forward.x ~= 0 and { x=0, y=1, z=0 } or (forward.y ~= 0 and { x=0, y=0, z=1 } or { x=1, y=0, z=0 })

--- a/technic/tools/sonic_screwdriver.lua
+++ b/technic/tools/sonic_screwdriver.lua
@@ -63,7 +63,7 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 	node.param2 = preservePart + rotationPart
 	minetest.swap_node(pos, node)
 
-	if not minetest.setting_getbool("creative_mode") then
+	if not technic.creative_mode then
 		meta1.charge = meta1.charge - 100
 		itemstack:set_metadata(minetest.serialize(meta1))
 		technic.set_RE_wear(itemstack, meta1.charge, sonic_screwdriver_max_charge)

--- a/technic/tools/tree_tap.lua
+++ b/technic/tools/tree_tap.lua
@@ -22,13 +22,15 @@ minetest.register_tool("technic:treetap", {
 		node.name = "moretrees:rubber_tree_trunk_empty"
 		minetest.swap_node(pos, node)
 		minetest.handle_node_drops(pointed_thing.above, {"technic:raw_latex"}, user)
-		local item_wear = tonumber(itemstack:get_wear())
-		item_wear = item_wear + 819
-		if item_wear > 65535 then
-			itemstack:clear()
-			return itemstack
+		if not technic.creative_mode then
+			local item_wear = tonumber(itemstack:get_wear())
+			item_wear = item_wear + 819
+			if item_wear > 65535 then
+				itemstack:clear()
+				return itemstack
+			end
+			itemstack:set_wear(item_wear)
 		end
-		itemstack:set_wear(item_wear)
 		return itemstack
 	end,
 })


### PR DESCRIPTION
- Removed cans (will add again per request)
- Added creative check to global namespace (checking only once as
requested by VanessaE)