### PR TITLE
Wrench fixes

### DIFF
--- a/wrench/depends.txt
+++ b/wrench/depends.txt
@@ -1,6 +1,6 @@
 default
-technic
-technic_chests
-technic_worldgen
+technic?
+technic_chests?
+technic_worldgen?
 intllib?
 

--- a/wrench/init.lua
+++ b/wrench/init.lua
@@ -36,10 +36,11 @@ end
 
 local function restore(pos, placer, itemstack)
 	local name = itemstack:get_name()
+	local node = minetest.get_node(pos)
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
 	local data = minetest.deserialize(itemstack:get_metadata())
-	minetest.set_node(pos, {name = data.name})
+	minetest.set_node(pos, {name = data.name, param2 = node.param2})
 	local lists = data.lists
 	for listname, list in pairs(lists) do
 		inv:set_list(listname, list)

--- a/wrench/init.lua
+++ b/wrench/init.lua
@@ -42,9 +42,6 @@ local function restore(pos, placer, itemstack)
 	local data = minetest.deserialize(itemstack:get_metadata())
 	minetest.set_node(pos, {name = data.name, param2 = node.param2})
 	local lists = data.lists
-	for listname, list in pairs(lists) do
-		inv:set_list(listname, list)
-	end
 	for name, value in pairs(data.metas) do
 		local meta_type = get_meta_type(data.name, name)
 		if meta_type == wrench.META_TYPE_INT then
@@ -54,6 +51,9 @@ local function restore(pos, placer, itemstack)
 		elseif meta_type == wrench.META_TYPE_STRING then
 			meta:set_string(name, value)
 		end
+	end
+	for listname, list in pairs(lists) do
+		inv:set_list(listname, list)
 	end
 	itemstack:take_item()
 	return itemstack

--- a/wrench/support.lua
+++ b/wrench/support.lua
@@ -66,6 +66,8 @@ function wrench:original_name(name)
 end
 
 function wrench:register_node(name, def)
-	self.registered_nodes[name] = def
+	if minetest.registered_nodes[name] then
+	    self.registered_nodes[name] = def
+	end
 end
 

--- a/wrench/technic.lua
+++ b/wrench/technic.lua
@@ -323,19 +323,21 @@ for i = 1, 15 do
 	})
 end
 
-for tier, _ in pairs(technic.machines) do
-	local ltier = tier:lower()
-	for i = 0, 8 do
-		wrench:register_node("technic:"..ltier.."_battery_box"..i, {
-			lists = {"src", "dst"},
-			metas = {infotext = STRING,
-				formspec = STRING,
-				[tier.."_EU_demand"] = INT,
-				[tier.."_EU_supply"] = INT,
-				[tier.."_EU_input"] = INT,
-				internal_EU_charge = INT,
-				last_side_shown = INT},
-		})
+if minetest.get_modpath("technic") then
+    for tier, _ in pairs(technic.machines) do
+		local ltier = tier:lower()
+		for i = 0, 8 do
+			wrench:register_node("technic:"..ltier.."_battery_box"..i, {
+				lists = {"src", "dst"},
+				metas = {infotext = STRING,
+					formspec = STRING,
+					[tier.."_EU_demand"] = INT,
+					[tier.."_EU_supply"] = INT,
+					[tier.."_EU_input"] = INT,
+					internal_EU_charge = INT,
+					last_side_shown = INT},
+			})
+		end
 	end
 end
 


### PR DESCRIPTION
Hi
I combined three fixes to the wrench code in this pull request. Please let me know if you'd prefer three separate pull requests.

Fixes:
* Make wrench usable independently of technic
* When restoring the contents of a container, the rotation of the container is now preserved (it used to be reset to the default rotation)
* When restoring a furnace (and maybe other containters as well?), the contents were not restored correctly. Now they are

FYI: while testing, I noticed that some of the technic containers are can not be picked up. E.g. technic:lv_compressor or technic:lv_grinder. Apparently they used to be called technic:compressor etc, but the wrench doesn't know about the new name, and refuses to pick them up...
Edit: submitted this as issue https://github.com/minetest-technic/technic/issues/213