### PR TITLE
allow activation/deactivation of frames/templates by config

### DIFF
--- a/technic/config.lua
+++ b/technic/config.lua
@@ -7,6 +7,7 @@ local defaults = {
 	enable_mining_laser = "true",
 	enable_flashlight = "false",
 	enable_wind_mill = "false",
+	enable_frames = "false",
 	enable_corium_griefing = "true",
 }
 

--- a/technic/machines/other/init.lua
+++ b/technic/machines/other/init.lua
@@ -3,7 +3,9 @@ local path = technic.modpath.."/machines/other"
 -- mesecons and tubes related
 dofile(path.."/injector.lua")
 dofile(path.."/constructor.lua")
-if minetest.get_modpath("mesecons_mvps") ~= nil then
+
+if technic.config:get_bool("enable_frames") and minetest.get_modpath("mesecons_mvps") ~= nil then
 	dofile(path.."/frames.lua")
 end
+
 dofile(path.."/anchor.lua")


### PR DESCRIPTION
have them deactivated by default due to a larger collection of associated issues
including but not limited to
* #170
* #216
* item duplication involving templates
* runaway machines
* traversal loop issues with huge machines leading to lag-outs