### PR TITLE
Configurable radiation

### DIFF
--- a/technic/config.lua
+++ b/technic/config.lua
@@ -9,6 +9,8 @@ local defaults = {
 	enable_wind_mill = "false",
 	enable_frames = "false",
 	enable_corium_griefing = "true",
+	enable_entity_radiation_damage = "true",
+	enable_longterm_radiation_damage = "true",
 }
 
 for k, v in pairs(defaults) do

--- a/technic/config.lua
+++ b/technic/config.lua
@@ -9,6 +9,7 @@ local defaults = {
 	enable_wind_mill = "false",
 	enable_frames = "false",
 	enable_corium_griefing = "true",
+	enable_radiation_protection = "true",
 	enable_entity_radiation_damage = "true",
 	enable_longterm_radiation_damage = "true",
 }

--- a/technic/radiation.lua
+++ b/technic/radiation.lua
@@ -304,9 +304,10 @@ end
 
 local function dmg_object(pos, object, strength)
 	local obj_pos = vector.add(object:getpos(), calculate_object_center(object))
+	local mul
 	if armor_enabled or entity_damage then
 		-- we need to check may the object be damaged even if armor is disabled
-		local mul = calculate_damage_multiplier(object)
+		mul = calculate_damage_multiplier(object)
 		if mul == 0 then
 			return
 		end

--- a/technic/radiation.lua
+++ b/technic/radiation.lua
@@ -264,7 +264,7 @@ local function calculate_base_damage(node_pos, object_pos, strength)
 	for ray_pos in technic.trace_node_ray(node_pos,
 			vector.direction(node_pos, object_pos), dist) do
 		local shield_name = minetest.get_node(ray_pos).name
-		shielding = shielding + node_radiation_resistance(shield_name) * 0.1
+		shielding = shielding + node_radiation_resistance(shield_name) * 0.025
 	end
 
 	local dmg = (strength * strength) /

--- a/technic/radiation.lua
+++ b/technic/radiation.lua
@@ -282,6 +282,9 @@ local function calculate_damage_multiplier(object)
 	if not ag then
 		return 0
 	end
+	if ag.immortal then
+		return 0
+	end
 	if ag.radiation then
 		return 0.01 * ag.radiation
 	end

--- a/technic/radiation.lua
+++ b/technic/radiation.lua
@@ -242,6 +242,7 @@ local cache_scaled_shielding = {}
 local rad_dmg_cutoff = 0.2
 local radiated_players = {}
 
+local armor_enabled = technic.config:get_bool("enable_radiation_protection")
 local entity_damage = technic.config:get_bool("enable_entity_radiation_damage")
 local longterm_damage = technic.config:get_bool("enable_longterm_radiation_damage")
 
@@ -303,15 +304,20 @@ end
 
 local function dmg_object(pos, object, strength)
 	local obj_pos = vector.add(object:getpos(), calculate_object_center(object))
-	local mul = calculate_damage_multiplier(object)
-	if mul == 0 then
-		return
+	if armor_enabled or entity_damage then
+		-- we need to check may the object be damaged even if armor is disabled
+		local mul = calculate_damage_multiplier(object)
+		if mul == 0 then
+			return
+		end
 	end
 	local dmg = calculate_base_damage(pos, obj_pos, strength)
 	if not dmg then
 		return
 	end
-	dmg = dmg * mul
+	if armor_enabled then
+		dmg = dmg * mul
+	end
 	apply_fractional_damage(object, dmg)
 	if longterm_damage and object:is_player() then
 		local pn = object:get_player_name()


### PR DESCRIPTION
This pull request contains several modifications:
1. Entities can be hurt by radiation (may be disabled in the config)
2. Long-term radiation effects may be disabled
3. Radiation protection is supported (using the “radiation” armor group instead of callbacks proposed earlier); this may be disabled too (see also [my pull request](https://github.com/stujones11/minetest-3d_armor/pull/53) to the 3d_armor mod)
4. Shielding is sane again (line 269→271 in technic/radiation.lua; the change I reverted looks accidental, as it makes a block of dirt be almost enough to protect from corium radiation)
