### PR TITLE
fix node dupe exploit in frames

### DIFF
--- a/technic/machines/other/frames.lua
+++ b/technic/machines/other/frames.lua
@@ -320,7 +320,7 @@ local nodeboxes= {
 			else
 				--local pointed_thing = {type = "node", under = pos}
 				if pointed_thing then
-					minetest.item_place_node(itemstack, placer, pointed_thing)
+					return minetest.item_place_node(itemstack, placer, pointed_thing)
 				end
 			end
 		end,


### PR DESCRIPTION
You can dupe nodes by placing them on a frame, because the on_rightclick wouldn't return the new itemstack.