### PR TITLE
Make mk3 drill in 3x3 mode drill nodes from top to bottom

### DIFF
--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -71,12 +71,6 @@ local function drill_dig_it1 (player)
 end
 
 local function drill_dig_it2 (pos,player)
-	drill_dig_it0 (pos,player)
-	pos.z=pos.z+1
-	drill_dig_it0 (pos,player)
-	pos.z=pos.z-2
-	drill_dig_it0 (pos,player)
-	pos.z=pos.z+1
 	pos.y=pos.y+1
 	drill_dig_it0 (pos,player)
 	pos.z=pos.z+1
@@ -84,7 +78,14 @@ local function drill_dig_it2 (pos,player)
 	pos.z=pos.z-2
 	drill_dig_it0 (pos,player)
 	pos.z=pos.z+1
-	pos.y=pos.y-2
+	pos.y=pos.y-1
+	drill_dig_it0 (pos,player)
+	pos.z=pos.z+1
+	drill_dig_it0 (pos,player)
+	pos.z=pos.z-2
+	drill_dig_it0 (pos,player)
+	pos.z=pos.z+1
+	pos.y=pos.y-1
 	drill_dig_it0 (pos,player)
 	pos.z=pos.z+1
 	drill_dig_it0 (pos,player)
@@ -93,12 +94,6 @@ local function drill_dig_it2 (pos,player)
 end
 
 local function drill_dig_it3 (pos,player)
-	drill_dig_it0 (pos,player)
-	pos.x=pos.x+1
-	drill_dig_it0 (pos,player)
-	pos.x=pos.x-2
-	drill_dig_it0 (pos,player)
-	pos.x=pos.x+1
 	pos.y=pos.y+1
 	drill_dig_it0 (pos,player)
 	pos.x=pos.x+1
@@ -106,7 +101,14 @@ local function drill_dig_it3 (pos,player)
 	pos.x=pos.x-2
 	drill_dig_it0 (pos,player)
 	pos.x=pos.x+1
-	pos.y=pos.y-2
+	pos.y=pos.y-1
+	drill_dig_it0 (pos,player)
+	pos.x=pos.x+1
+	drill_dig_it0 (pos,player)
+	pos.x=pos.x-2
+	drill_dig_it0 (pos,player)
+	pos.x=pos.x+1
+	pos.y=pos.y-1
 	drill_dig_it0 (pos,player)
 	pos.x=pos.x+1
 	drill_dig_it0 (pos,player)


### PR DESCRIPTION
The mk3 mining drill, when operating in 3x3 mode, first drills the horizontal row being pointed at, then the row above, then the row below. When the top row contains falling nodes, they end up not being drilled, as they fall after the middle row has been drilled.

Before: https://www.youtube.com/watch?v=GuS-UVGAlSk

After: https://www.youtube.com/watch?v=eir_1wRPuMw