### PR TITLE
Pass info to called technic_run at which stage we are.

### DIFF
--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -13,7 +13,7 @@ local run = function(pos, node, run_name)
 	local demand = 10000
 	local remain = 0.9
 
-	if run_name == technic.receive then 
+	if run_name == technic.receiver then 
 		-- do not run TWICE (it is PR-RE machine), save lua cycles
 		return 
 	end 

--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -9,9 +9,12 @@
 
 local S = technic.getter
 
-local run = function(pos, node)
+local run = function(pos, node, run_name)
 	local demand = 10000
 	local remain = 0.9
+
+	if run_name == "RE" then return end -- do not run TWICE (it is PR-RE machine), save lua cycles
+
 	-- Machine information
 	local machine_name  = S("Supply Converter")
 	local meta          = minetest.get_meta(pos)

--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -13,7 +13,7 @@ local run = function(pos, node, run_name)
 	local demand = 10000
 	local remain = 0.9
 
-	if run_name == "RE" then 
+	if run_name == technic.receive then 
 		-- do not run TWICE (it is PR-RE machine), save lua cycles
 		return 
 	end 

--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -13,7 +13,10 @@ local run = function(pos, node, run_name)
 	local demand = 10000
 	local remain = 0.9
 
-	if run_name == "RE" then return end -- do not run TWICE (it is PR-RE machine), save lua cycles
+	if run_name == "RE" then 
+		-- do not run TWICE (it is PR-RE machine), save lua cycles
+		return 
+	end 
 
 	-- Machine information
 	local machine_name  = S("Supply Converter")

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -208,7 +208,7 @@ minetest.register_abm({
 		end
 		
 		-- Run all the nodes
-		local function run_nodes(list)
+		local function run_nodes(list, run_name)
 			for _, pos2 in ipairs(list) do
 				technic.get_or_load_node(pos2)
 				local node2 = minetest.get_node(pos2)
@@ -217,14 +217,14 @@ minetest.register_abm({
 					nodedef = minetest.registered_nodes[node2.name]
 				end
 				if nodedef and nodedef.technic_run then
-					nodedef.technic_run(pos2, node2)
+					nodedef.technic_run(pos2, node2, run_name)
 				end
 			end
 		end
 		
-		run_nodes(PR_nodes)
-		run_nodes(RE_nodes)
-		run_nodes(BA_nodes)
+		run_nodes(PR_nodes, "PR")
+		run_nodes(RE_nodes, "RE")
+		run_nodes(BA_nodes, "BA")
 
 		-- Strings for the meta data
 		local eu_demand_str    = tier.."_EU_demand"

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -222,9 +222,9 @@ minetest.register_abm({
 			end
 		end
 		
-		run_nodes(PR_nodes, "PR")
-		run_nodes(RE_nodes, "RE")
-		run_nodes(BA_nodes, "BA")
+		run_nodes(PR_nodes, technic.producer)
+		run_nodes(RE_nodes, technic.receiver)
+		run_nodes(BA_nodes, technic.battery)
 
 		-- Strings for the meta data
 		local eu_demand_str    = tier.."_EU_demand"


### PR DESCRIPTION
This lets to save cpu/lua cycles for PR/RE machines like supply converters. It does not break ones not using info, but patching (same way as supply convert is patched in this PR), saves half of execution time on not running same code over same data TWICE.