### PR TITLE
Fixed set mode for mining drill mk2 and mk3

### DIFF
--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -252,7 +252,7 @@ local function mining_drill_mk2_setmode(user,itemstack)
 	mode=mode+1
 	if mode>=5 then mode=1 end
 	minetest.chat_send_player(player_name, S("Mining Drill Mk%d Mode %d"):format(2, mode)..": "..mining_drill_mode_text[mode][1])
-	item["name"]="technic:mining_drill_mk2_"..mode
+    itemstack:set_name("technic:mining_drill_mk2_"..mode);
 	meta["mode"]=mode
     itemstack:set_metadata(minetest.serialize(meta))
 	return itemstack
@@ -275,7 +275,7 @@ local function mining_drill_mk3_setmode(user,itemstack)
 	mode=mode+1
 	if mode>=6 then mode=1 end
 	minetest.chat_send_player(player_name, S("Mining Drill Mk%d Mode %d"):format(3, mode)..": "..mining_drill_mode_text[mode][1])
-	item["name"]="technic:mining_drill_mk3_"..mode
+    itemstack:set_name("technic:mining_drill_mk3_"..mode);
 	meta["mode"]=mode
     itemstack:set_metadata(minetest.serialize(meta))
 	return itemstack

--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -254,8 +254,7 @@ local function mining_drill_mk2_setmode(user,itemstack)
 	minetest.chat_send_player(player_name, S("Mining Drill Mk%d Mode %d"):format(2, mode)..": "..mining_drill_mode_text[mode][1])
 	item["name"]="technic:mining_drill_mk2_"..mode
 	meta["mode"]=mode
-	item["metadata"]=minetest.serialize(meta)
-	itemstack:replace(item)
+    itemstack:set_metadata(minetest.serialize(meta))
 	return itemstack
 end
 
@@ -278,8 +277,7 @@ local function mining_drill_mk3_setmode(user,itemstack)
 	minetest.chat_send_player(player_name, S("Mining Drill Mk%d Mode %d"):format(3, mode)..": "..mining_drill_mode_text[mode][1])
 	item["name"]="technic:mining_drill_mk3_"..mode
 	meta["mode"]=mode
-	item["metadata"]=minetest.serialize(meta)
-	itemstack:replace(item)
+    itemstack:set_metadata(minetest.serialize(meta))
 	return itemstack
 end
 


### PR DESCRIPTION
With the latest version of minetest, the mode of the mining drills mk2 and mk3 could not be set. The small change in technic/tools/mining_drill.lua fixes this problem.