### PR TITLE
Fixes for network calculation issues

### DIFF
--- a/technic/machines/init.lua
+++ b/technic/machines/init.lua
@@ -8,6 +8,7 @@ dofile(path.."/MV/init.lua")
 dofile(path.."/HV/init.lua")
 
 dofile(path.."/switching_station.lua")
+dofile(path.."/power_monitor.lua")
 dofile(path.."/supply_converter.lua")
 
 dofile(path.."/other/init.lua")

--- a/technic/machines/power_monitor.lua
+++ b/technic/machines/power_monitor.lua
@@ -1,0 +1,61 @@
+-- POWER MONITOR
+-- The power monitor can be used to monitor how much power is available on a network,
+-- similarly to the old "slave" switching stations.
+
+local S = technic.getter
+
+minetest.register_craft({
+	output = "technic:power_monitor",
+	recipe = {
+		{"",                 "",                       ""},
+		{"",                 "technic:machine_casing", "default:copper_ingot"},
+		{"technic:lv_cable", "technic:lv_cable",       "technic:lv_cable"}
+	}
+})
+
+minetest.register_node("technic:power_monitor",{
+	description = S("Power Monitor"),
+	tiles  = {"technic_water_mill_top_active.png", "technic_water_mill_top_active.png",
+                  "technic_water_mill_top_active.png", "technic_water_mill_top_active.png",
+	          "technic_water_mill_top_active.png", "technic_water_mill_top_active.png"},
+	groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2, technic_all_tiers=1, technic_machine=1},
+	connect_sides = {"bottom"},
+	sounds = default.node_sound_wood_defaults(),
+	on_construct = function(pos)
+		local meta = minetest.get_meta(pos)
+		meta:set_string("infotext", S("Power Monitor"))
+	end,
+})
+
+minetest.register_abm({
+	nodenames = {"technic:power_monitor"},
+	label = "Power Monitor",
+	interval   = 1,
+	chance     = 1,
+	action = function(pos, node, active_object_count, active_object_count_wider)
+		local meta = minetest.get_meta(pos)
+		local network_hash = technic.cables[minetest.hash_node_position(pos)]
+		local network = network_hash and minetest.get_position_from_hash(network_hash)
+		local sw_pos = network and {x=network.x,y=network.y+1,z=network.z}
+		local timeout = 0
+		for tier in pairs(technic.machines) do
+			timeout = math.max(meta:get_int(tier.."_EU_timeout"),timeout)
+		end
+		if timeout > 0 and sw_pos and minetest.get_node(sw_pos).name == "technic:switching_station" then
+			local sw_meta = minetest.get_meta(sw_pos)
+			local supply = sw_meta:get_int("supply")
+			local demand = sw_meta:get_int("demand")
+			meta:set_string("infotext",
+					S("Power Monitor. Supply: @1 Demand: @2",
+					technic.pretty_num(supply), technic.pretty_num(demand)))
+		else
+			meta:set_string("infotext",S("Power Monitor Has No Network"))
+		end
+	end,
+})
+
+for tier in pairs(technic.machines) do
+	-- RE in order to use the "timeout" functions, although it consumes 0 power
+	technic.register_machine(tier, "technic:power_monitor", "RE")
+end
+

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -20,8 +20,13 @@ local function clear_networks(pos)
 		{x=pos.x,   y=pos.y,   z=pos.z+1},
 		{x=pos.x,   y=pos.y,   z=pos.z-1}}
 	for _,connected_pos in pairs(positions) do
-		if technic.cables[minetest.hash_node_position(connected_pos)] then
-			technic.networks[technic.cables[minetest.hash_node_position(connected_pos)]] = nil
+		local net = technic.cables[minetest.hash_node_position(connected_pos)]
+		if net and technic.networks[net] then
+			for _,v in pairs(technic.networks[net].all_nodes) do
+				local pos1 = minetest.hash_node_position(v)
+				technic.cables[pos1] = nil
+			end
+			technic.networks[net] = nil
 		end
 	end
 end


### PR DESCRIPTION
This fixes several issues:
* More than one switching station could become active on large networks
** Switching stations now semi-permanently become disabled if another is present
** Power monitors have been added to replace the function of "slave" switching stations, to discourage overuse of switching stations
* Networks did not reliably "split" when cutting a cable
** I "may" have caused this issue, but I believe it is solved by this
* Machines did not run without a player near the switching station
** Active switching stations now forceload themselves, and free the forceloaded block if disabled, dug, or disconnected
** Machines are only loaded to run them (as before), so only one mapblock (or two if the bottom edge of the switching station is a mapblock boundary) is loaded
** Cables are still only loaded during a full network recalculation