### PR TITLE
Add backward compatibility to the new supply converter

### DIFF
--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -68,7 +68,15 @@ local run = function(pos, node, run_stage)
 	-- Machine information
 	local machine_name  = S("Supply Converter")
 	local meta          = minetest.get_meta(pos)
-	local enabled = meta:get_string("enabled") ~= "0" and (meta:get_int("mesecon_mode") == 0 or meta:get_int("mesecon_effect") ~= 0)
+	local enabled       = meta:get_string("enabled")
+	if enabled == "" then
+		-- Backwards compatibility
+		minetest.registered_nodes["technic:supply_converter"].on_construct(pos)
+		enabled = true
+	else
+		enabled = enabled == "1"
+	end
+	enabled = enabled and (meta:get_int("mesecon_mode") == 0 or meta:get_int("mesecon_effect") ~= 0)
 	local demand = enabled and meta:get_int("power") or 0
 
 	local pos_up        = {x=pos.x, y=pos.y+1, z=pos.z}


### PR DESCRIPTION
(Re-)initializes supply converter metadata (including formspec) if it is absent for whatever reason, e.g. if the converter was built before 314d8c6c23b9ada33b7944391051f0ca6e5e4124